### PR TITLE
add a makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.bash_history
+.viminfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu
+
+RUN apt-get update && \
+        apt-get --yes install \
+                libxml-xpath-perl \
+                make \
+                curl \
+                ruby \
+                vim
+
+RUN gem install cddl cbor-diag
+
+CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ eat_cddl := eat.cddl
 CLEANFILES += $(eat_cddl)
 
 $(eat_cddl): $(eat_xml)
-	$(xpath) -n -q -e '//section[@anchor="collected-cddl"]//artwork/text()' $< \
+	$(xpath) -n -q -e '//section[@anchor="collected-cddl"]//sourcecode/text()' $< \
 		| sed -e 's/\&amp;/\&/g' \
 		> $@
 
@@ -56,3 +56,22 @@ check: $(eat_cddl) $(cbors)
 
 .PHONY: clean
 clean: ; $(RM) $(CLEANFILES)
+
+# docker
+docker_image := eat-test-sandbox
+docker_wdir := /root
+docker_run_it := docker run -it -w $(docker_wdir) -v $(shell pwd):$(docker_wdir) $(docker_image)
+
+build-docker: ; docker build -t $(docker_image) .
+.PHONY: build-docker
+
+run-docker: ; $(docker_run_it)
+.PHONY: run-docker
+
+# Execute any Makefile target into the docker sandbox
+# E.g., to run the "check" target in the sandbox, do:
+#   make docker-check
+# To run the "clean" target in the sandbox, do:
+#   make docker-clean
+docker-%:
+	$(docker_run_it) bash -c "make $(subst docker-,,$@)"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+.DEFAULT_GOAL := check
+
+# tools
+curl ?= curl
+xpath ?= xpath
+cddl ?= cddl
+diag2cbor ?= diag2cbor.rb
+
+# upstream repo configuration
+eat_repo_baseurl ?= https://ietf-rats-wg.github.io/eat
+# Set eat_repo_branch if you need to work with a branch other than master/main.
+# For example, if you need to work with a branch named CoSWID, do:
+#   make eat_repo_branch=CoSWID
+# Check https://ietf-rats-wg.github.io/eat/ for the branches that are currently
+# available.
+eat_repo_branch ?=
+ifeq ($(eat_repo_branch),)
+  eat_repo := $(eat_repo_baseurl)
+else
+  eat_repo := $(eat_repo_baseurl)/$(eat_repo_branch)
+endif
+
+eat_xml := draft-ietf-rats-eat.xml
+CLEANFILES += $(eat_xml)
+
+eat_cddl := eat.cddl
+CLEANFILES += $(eat_cddl)
+
+$(eat_cddl): $(eat_xml)
+	$(xpath) -n -q -e '//section[@anchor="collected-cddl"]//artwork/text()' $< \
+		| sed -e 's/\&amp;/\&/g' \
+		> $@
+
+$(eat_xml):
+	if ! $(curl) -s -w "%{http_code}" -O $(eat_repo)/$@ | grep 200 ; then \
+                echo ">>> failed downloading $(eat_repo)/$@" ; \
+                rm -f $@ ; \
+                exit 1 ; \
+        fi
+
+# TODO decide a file name convention to identify the valid test cases.
+# TODO add more valid test cases
+diags := src/secboot/valid1.diag
+
+cbors := $(diags:.diag=.cbor)
+CLEANFILES += $(cbors)
+
+%.cbor: %.diag ; $(diag2cbor) $< > $@
+
+# Check the valid test cases against the EAT CDDL
+.PHONY: check
+check: $(eat_cddl) $(cbors)
+	for f in $(cbors) ; do \
+		$(cddl) $< validate $$f ; \
+	done
+
+.PHONY: clean
+clean: ; $(RM) $(CLEANFILES)

--- a/README.md
+++ b/README.md
@@ -7,21 +7,23 @@ The .diag files describe the tokens in CBOR diag format. The
 diag-format comments, the ones between '/' and '/' describe
 the token and its testing use.
 
-The .hex files are text files with lines of hex digits. For example
+The .hex files are text files with lines of hex digits. For example:
+```
     010203dead
     beef
-Lines beginning with "#" are comment lines that are not 
+```
+Lines beginning with `#` are comment lines that are not
 encoded into the token. The .diag format is preferred, but
 some malformed and invalid CBOR is needed for some tests
 and can't be represented in diag.
 
 The .c file src tokens will be deprecated soon in favor
 of the .hex format.
-The .c files descibe the token as a C string. The .diag 
+The .c files descibe the token as a C string. The .diag
 files are preferred but can't represent tokens with truly
 malformed and invalid CBOR that is needed for some tests.
 
-The script script/t2c.sh will take the .diag files and .hex files
+The script `script/t2c.sh` will take the .diag files and .hex files
 and make a .c and .h file out of them that contains a byte
 array for each token. This is good for testing embedded C
 implementations of EAT.
@@ -43,14 +45,13 @@ Here's the file naming convention:
     BASEDIR = "src" "/" ( CLAIMNAME / FEATURE )
     CLAIMNAME = <the list of EAT claims>
     FEATURE = <a list of feaures or areas to test that are not claims>
-    SYNOPSIS = 1* ( ALPHA / "_" / DIGIT ) 
+    SYNOPSIS = 1* ( ALPHA / "_" / DIGIT )
     EXT = "diag" / "hex"
 ```
 
 E.g.:
-
-* src/euid/valid_rand_type.diag
-* src/euid/invalid_unknown_type.diag
+* `src/euid/valid_rand_type.diag`
+* `src/euid/invalid_unknown_type.diag`
 
 # Docker
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,40 @@ can't be checked because some will be malformed input that
 is legal CBOR, but not legal EAT.
 
 Here's the file naming convention:
-
+```
     TESTVECTOR = BASEDIR "/" ( "valid" / "invalid" ) "_" SYNOPSIS "." EXT
     BASEDIR = "src" "/" ( CLAIMNAME / FEATURE )
     CLAIMNAME = <the list of EAT claims>
     FEATURE = <a list of feaures or areas to test that are not claims>
     SYNOPSIS = 1* ( ALPHA / "_" / DIGIT ) 
     EXT = "diag" / "hex"
+```
 
 E.g.:
+
 * src/euid/valid_rand_type.diag
 * src/euid/invalid_unknown_type.diag
+
+# Docker
+
+To build the docker sandbox, do:
+```
+make build-docker
+```
+
+To enter the sandbox and run an interactive shell, do:
+```
+make run-docker
+```
+
+From within the sandbox, all the Makefile targets (e.g., `check`, `clean`,
+etc.) are directly available; e.g.:
+```
+sandbox# make check
+```
+
+In order to run a Makefile target in the sandbox from the host, add a `docker-`
+prefix, e.g.:
+```
+host$ make docker-check`
+```


### PR DESCRIPTION
Add an initial makefile that fetches the editor's copy of the EAT spec and extracts the CDDL.

This change depends on ietf-rats-wg/eat#104 being merged.